### PR TITLE
Update format-google-calendar.js

### DIFF
--- a/format-google-calendar.js
+++ b/format-google-calendar.js
@@ -17,7 +17,7 @@ var formatGoogleCalendar = (function() {
         config = settings;
         var finalURL = settings.calendarUrl;
 
-        if(settings.recurringEvents) finalURL = finalURL.concat("&singleEvents=true");
+        if(settings.recurringEvents) finalURL = finalURL.concat("&singleEvents=true&orderBy=starttime");
 
         //Get JSON, parse it, transform into list items and append it to past or upcoming events list
         jQuery.getJSON(finalURL, function(data) {


### PR DESCRIPTION
update list request to orderBy "starttime" if recurring events are to be shown with "singleEvents=true". otherwise an early defined recurrent event can potentially dominate the generated list.