### PR TITLE
Added serverTZ option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The library could be found in the <b>dist</b> folder of this repository.
 * upcomingHeading (string, heading of upcoming events)<br>
 * pastHeading (string, heading of past events)<br>
 * format (array, describes format in which should be data displayed, it is a list of strings where wildcards are <code><b>\*date\*</b>, <b>\*summary\*</b>, <b>\*description\*</b>, <b>\*location\*</b></code>, if a string is a different value than a wildcard the string will be appended to the final output)<br>
+* serverTZ (boolean, determines whether to show times of events as returned by the server or use the browser's timezone)<br>
 ## Notes
 You can customize <code><b>calendarUrl</b></code> with use of various parameters which are listed in the <a target="_blank" href="https://developers.google.com/google-apps/calendar/v3/reference/events/list"> Google Calendar API page</a>. Following options of this library: <code><b>recurringEvents</b></code>, <code><b>timeMin</b></code>, <code><b>timeMax</b></code> operate directly with the Google Calendar API url parameters.
 

--- a/src/app.js
+++ b/src/app.js
@@ -218,7 +218,15 @@ window.formatGoogleCalendar = (() => {
 
     //Get temp array with information abou day in followin format: [day number, month number, year, hours, minutes]
     const getDateInfo = date => {
-        date = new Date(date);
+	if (config.serverTZ && typeof date === 'string') {
+            // Use the timezone as returned by the server
+            var b = date.split(/\D/);
+            date = new Date(b[0], b[1]-1, b[2], b[3], b[4], b[5]);
+        }
+        else {
+            // Use the timezone of the browser (or the argument date has already been converted to a Date object)
+            date = new Date(date);
+        }
         return [date.getDate(), date.getMonth(), date.getFullYear(), date.getHours(), date.getMinutes(), 0, 0];
     };
 
@@ -416,7 +424,8 @@ window.formatGoogleCalendar = (() => {
                 pastHeading: '<h2>Past events</h2>',
                 format: ['*date*', ': ', '*summary*', ' &mdash; ', '*description*', ' in ', '*location*'],
                 timeMin: undefined,
-                timeMax: undefined
+                timeMax: undefined,
+                serverTZ: false
             };
 
             settings = mergeOptions(settings, settingsOverride);


### PR DESCRIPTION
Thanks for a great package! The datetimes are currently displayed using the browser's timezone, regardless of the timezone returned by the Google calendar. I added an option serverTZ that allows the datetimes to be displayed as returned by the server (i.e., using the timezone specified by the Google calendar). This option defaults to false, i.e., the current behavior. 